### PR TITLE
[minor] Corrected a typo in redeem rewards prompt.

### DIFF
--- a/packages/miami-ui/components/Dashboard/Redeem/RedeemStacking.js
+++ b/packages/miami-ui/components/Dashboard/Redeem/RedeemStacking.js
@@ -194,19 +194,30 @@ const RedeemStacking = () => {
   return (
     <div className={styles.redeemStacking}>
       <h2 className={styles.h2}>Redeem stacking rewards</h2>
-      <p>
-        You have a total of {" " + (totalSTX / 1000000).toLocaleString() + " "}
-        redeemable STX from the below cycles. Send the transaction below to
-        redeem them.
-      </p>
-      <p>You'll need to send a transaction for every cycle.</p>
       <p>(Current Cycle: {cycleNum})</p>
-      {isLoading && (
+      {isLoading ? (
         <div>
           Checking for cycle rewards... {percentageChecked}% (Please wait)
         </div>
-      )}
-      {buttons && buttons}
+        ) : (
+          <div>
+            <p>{`You have a total of ${(totalSTX / 1000000).toLocaleString()} redeemable STX \n
+              from the previous cycles.`} </p>
+              { buttons.length > 0 ? (
+                <div>
+                  <p>You'll need to send a transaction for every cycle.</p>
+                  {buttons && buttons}
+                </div>
+                ) : (
+                  <p> If you've stacked before, you'll have to wait until the current cycle ends
+                    to redeem your rewards.</p>
+                )
+              }
+          </div>
+        )
+      }
+
+      
     </div>
   );
 };

--- a/packages/miami-ui/components/Dashboard/Redeem/RedeemStacking.js
+++ b/packages/miami-ui/components/Dashboard/Redeem/RedeemStacking.js
@@ -196,7 +196,7 @@ const RedeemStacking = () => {
       <h2 className={styles.h2}>Redeem stacking rewards</h2>
       <p>
         You have a total of {" " + (totalSTX / 1000000).toLocaleString() + " "}
-        redeemable STX from the below cycles. Send the transactions below to
+        redeemable STX from the below cycles. Send the transaction below to
         redeem them.
       </p>
       <p>You'll need to send a transaction for every cycle.</p>

--- a/packages/miami-ui/components/Dashboard/Redeem/RedeemStacking.js
+++ b/packages/miami-ui/components/Dashboard/Redeem/RedeemStacking.js
@@ -201,8 +201,8 @@ const RedeemStacking = () => {
         </div>
         ) : (
           <div>
-            <p>{`You have a total of ${(totalSTX / 1000000).toLocaleString()} redeemable STX \n
-              from the previous cycles.`} </p>
+            <p>{`You have a total of ${(totalSTX / 1000000).toLocaleString()} redeemable STX 
+              from previous cycles.`} </p>
               { buttons.length > 0 ? (
                 <div>
                   <p>You'll need to send a transaction for every cycle.</p>


### PR DESCRIPTION
### Description ###
Corrected a minor typo in the `RedeemStacking.js` component to tell users that only one transaction is necessary to redeem their STX.